### PR TITLE
Fix: Bump versions for Ruby dependencies

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,11 +8,14 @@ GIT
 GEM
   remote: http://rubygems.org/
   specs:
-    capistrano (3.4.0)
+    airbrussh (1.3.0)
+      sshkit (>= 1.6.1, != 1.7.0)
+    capistrano (3.9.0)
+      airbrussh (>= 1.0.0)
       i18n
       rake (>= 10.0.0)
-      sshkit (~> 1.3)
-    capistrano-bundler (1.1.4)
+      sshkit (>= 1.9.0)
+    capistrano-bundler (1.2.0)
       capistrano (~> 3.1)
       sshkit (~> 1.2)
     capistrano-npm (1.0.2)
@@ -20,13 +23,21 @@ GEM
     capistrano-rvm (0.1.2)
       capistrano (~> 3.0)
       sshkit (~> 1.2)
-    i18n (0.7.0)
+    ffi (1.9.18)
+    i18n (0.8.6)
     net-scp (1.2.1)
       net-ssh (>= 2.6.5)
-    net-ssh (3.0.2)
-    rake (10.5.0)
-    sass (3.4.16)
-    sshkit (1.8.1)
+    net-ssh (4.1.0)
+    rake (12.0.0)
+    rb-fsevent (0.10.2)
+    rb-inotify (0.9.10)
+      ffi (>= 0.5.0, < 2)
+    sass (3.5.1)
+      sass-listen (~> 4.0.0)
+    sass-listen (4.0.0)
+      rb-fsevent (~> 0.9, >= 0.9.4)
+      rb-inotify (~> 0.9, >= 0.9.7)
+    sshkit (1.14.0)
       net-scp (>= 1.1.2)
       net-ssh (>= 2.8.0)
 
@@ -42,4 +53,4 @@ DEPENDENCIES
   sass
 
 BUNDLED WITH
-   1.11.2
+   1.15.3

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -1,5 +1,5 @@
 # config valid only for current version of Capistrano
-lock '3.4.0'
+lock '3.9.0'
 
 set :application, 'hacknotts'
 set :repo_url, 'git@github.com:HackSocNotts/hacknotts.com.git'


### PR DESCRIPTION
Without this patch, running `bundle exec cap staging deploy` will fail
on `ruby 2.4.1p111 (2017-03-22 revision 58053) [x86_64-linux]` with the
error:

    Failure/Error: key.e = e

    NoMethodError:
      undefined method `e=' for #<OpenSSL::PKey::RSA:0x007fba39cb1858>
      Did you mean?  e

This seems to be an issue with changes done to Ruby + OpenSSL[1]. By
bumping our dependencies, we're able to push changes again.

[1]: https://github.com/nov/json-jwt/issues/45